### PR TITLE
support for context menu in file explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "url": "https://github.com/tomoki1207/vscode-pdfviewer/issues"
   },
   "activationEvents": [
-    "onLanguage:pdf"
+    "onLanguage:pdf",
+    "onCommand:extension.pdf-preview"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -46,7 +47,22 @@
         "scopeName": "text.plain, text.plain.pdf",
         "path": "./syntaxes/pdf.tmLanguage"
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "extension.pdf-preview",
+        "title": "View PDF"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "resourceLangId == pdf",
+          "command": "extension.pdf-preview",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,10 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 function showDocumentPreview(document: vscode.TextDocument): void {
-  if (document.languageId === "pdf") {
-    showPreview(document.uri);
+  if (document.languageId === "pdf" && document.uri.scheme !== "pdf-preview") {
+    vscode.commands.executeCommand("workbench.action.closeActiveEditor").then(() => {
+      showPreview(document.uri);
+    });
   }
 }
 
@@ -38,12 +40,11 @@ function showPreview(uri: vscode.Uri): void {
 
   let basename = path.basename(uri.fsPath);
   let columns = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : 1;
-  vscode.commands.executeCommand("workbench.action.closeActiveEditor")
-    .then(() => vscode.commands.executeCommand("vscode.previewHtml",
-      buildPreviewUri(uri),
-      columns,
-      basename))
-    .then(null, vscode.window.showErrorMessage);
+  vscode.commands.executeCommand("vscode.previewHtml",
+    buildPreviewUri(uri),
+    columns,
+    basename)
+  .then(null, vscode.window.showErrorMessage);
 }
 
 function buildPreviewUri(uri: vscode.Uri): vscode.Uri {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
     showDocumentPreview(document);
   });
 
-  const previewCmd = vscode.commands.registerCommand('extension.pdf-preview', (uri: vscode.Uri) => {
+  const previewCmd = vscode.commands.registerCommand("extension.pdf-preview", (uri: vscode.Uri) => {
     showPreview(uri);
   });
 


### PR DESCRIPTION
With this, you can right click on the file explorer and see "View PDF", only in case the file is a `.pdf`.
Plus: this should work also for files that VS Code does not let you open normally (the known issue "this file is binary").