### PR TITLE
Run extension locally when using remote development

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
     "vsce": "^1.71.0",
     "vscode-dts": "^0.3.1",
     "vscode-test": "^1.3.0"
-  }
+  },
+  "extensionKind": ["ui"]
 }


### PR DESCRIPTION
This extension has to execute in `ui` and not `workspace` (default) in order to work properly with VSCode Remote development (i.e. SSH, Docker, WSL), as described in https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location

Without this change nothing is visible in the UI (blank tab).

As a temporary workaround one may add to VSCode settings:
```{
  "remote.extensionKind": {
    "tomoki1207.pdf": ["ui"],
  }
} 