### PR TITLE
Allow pdf viewer to work in an untrusted workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "contributes": {
     "capabilities": {
       "untrustedWorkspaces": {
-        "supported": false
+        "supported": true
       }
     },
     "customEditors": [{

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
+    "capabilities": {
+      "untrustedWorkspaces": {
+        "supported": false
+      }
+    },
     "customEditors": [{
       "viewType": "pdf.preview",
       "displayName": "Pdf Preview",


### PR DESCRIPTION
Hello :wave: I'm from the VS Code team.

Recently, we have been exploring a security feature we refer to as _Workspace Trust_. This feature is intended to centralize and unify a security conscious decision required by a variety of VS Code features. With workspace trust, the user will be able to declare whether or not they trust the folder that is opened in VS Code before these features are executed. A detailed guide regarding workspace trust can be found in [issue #120251](https://github.com/microsoft/vscode/issues/120251).

### Why you should care

Custom editors rely on an extension host based model which means that if your extension cannot activate in an untrusted scenario then things like restoring, and general operation will not work. This can lead to a bad user experience or even data loss.


After reviewing your codebase, I believe that the extension doesn't assume any workspace content is code and therefore it is ok to operate in the untrusted state. Let me know if you have any questions and I would be happy to assist. The hope is to turn workspace trust on by default in the next release of VS Code so please let me know if there's anything blocking you from merging this PR.