### PR TITLE
feat: add debounce to panel closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,13 @@
           "enum": [
             "none", "odd", "even"
           ]
-        }
+        },
+				"pdf-preview.default.disposeDelay": {
+					"markdownDescription": "The default delay (in ms) before the preview is closed after file deletion. Unset this to prevent closing.",
+					"type": "string",
+					"default": "0",
+					"pattern": "^\\d*$"
+				}
       }
     }
   },

--- a/src/pdfPreview.ts
+++ b/src/pdfPreview.ts
@@ -70,7 +70,7 @@ export class PdfPreview extends Disposable {
       }
     }));
     this._register(watcher.onDidDelete((e) => {
-      const disposeDelay = vscode.window.getConfiguration('pdf-preview').get('default.disposeDelay');
+      const disposeDelay = vscode.workspace.getConfiguration('pdf-preview').get('default.disposeDelay');
       if (disposeDelay === '') return;
       disposeTimeout = setTimeout(() => {
         if (e.toString() === this.resource.toString()) {


### PR DESCRIPTION
This PR adds a delay to panel closure after a file is deleted. In addition, if a file is created in-place within the delay timeframe, the panel will reload and cancel panel closure.

Fixes #112