### PR TITLE
Support Unicode in PDF by passing the right cMapUrl to pdf.js

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,6 +40,7 @@
   }
   window.addEventListener('load', function () {
     const config = loadConfig()
+    PDFViewerApplicationOptions.set('cMapUrl', config.cMapUrl)
     PDFViewerApplication.open(config.path)
     PDFViewerApplication.initializedPromise.then(() => {
       const defaults = config.defaults

--- a/src/pdfPreview.ts
+++ b/src/pdfPreview.ts
@@ -105,6 +105,7 @@ export class PdfPreview extends Disposable {
 
     const config = vscode.workspace.getConfiguration('pdf-preview');
     const settings = {
+      cMapUrl: resolveAsUri('lib', 'web', 'cmaps/').toString(),
       path: docPath.toString(),
       defaults: {
         cursor: config.get('default.cursor') as string,


### PR DESCRIPTION
This PR fixes the bug that Unicode characters can't be rendered in vscode-pdfviewer by setting the right `cMapUrl` option of the PDF viewer.

`cmaps` are short for "character maps" and it's required by the core when rendering Unicode characters in PDF. By default, the option's value is `../web/cmaps` ([code](https://github.com/mozilla/pdf.js/blob/bb81f4029ab46d4d34d425580012cb1fc20446fc/web/app_options.js#L199)). This will work if we are using the default `web/viewer.html` packaged in the dist of pdf.js. But because the PDF viewer is rendered inside an iframe in VS Code, `../web/cmaps` isn't the right relative path for the cmaps. To fix the bug, we need to set the right cmap URL before rendering the PDF.

The PDF viewer has an option `cMapUrl` which tells it where to find the cmap files ([ref](https://github.com/mozilla/pdf.js/blob/81f5835cd7024827e0671ccd66525df98fb15703/src/display/api.js#L163-L164)). We can get the URL of the cmaps in `pdfPreview.ts` and set the option on load. 

Because pdf.js expects the option to have trailing slash, the trailing slash after `cmaps` when generating the URL is required.

Tested with a few PDFs with Chinese characters and they are rendered without problems.

![image](https://user-images.githubusercontent.com/70373/132115587-fd851d12-5bdc-4075-a9e6-31e02f4320ab.png)