### PR TITLE
Fix #118: Preserve the current page number and zoom level on reload.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,15 @@
       PDFViewerApplication.eventBus.on('documentloaded', optsOnLoad)
     })
     window.addEventListener('message', function () {
-      window.PDFViewerApplication.open(config.path)
+      const { currentPageNumber, currentScaleValue } = PDFViewerApplication.pdfViewer
+      PDFViewerApplication.open(config.path).then(() => {
+        const optsOnReload = () => {
+          PDFViewerApplication.pdfViewer.currentPageNumber = currentPageNumber
+          PDFViewerApplication.pdfViewer.currentScaleValue = currentScaleValue
+          PDFViewerApplication.eventBus.off('documentloaded', optsOnReload)
+        }
+        PDFViewerApplication.eventBus.on('documentloaded', optsOnReload)
+      })
     });
   }, { once: true });
 


### PR DESCRIPTION
This is a suggestion for a fix of #118.
It doesn't preserve the exact scroll location, only the page number, which will cause a jump to the top of the page on reload.
But I still think it's an improvement compared to jumping back to the start of the document on each reload.

The underlying pdf.js already [supports this automatically](https://github.com/mozilla/pdf.js/issues/6847#issuecomment-451761859), but it relies on detecting the [page was reloaded](https://github.com/mozilla/pdf.js/pull/10424) which I couldn't find any way of achieving when pdf.js is embedded in vscode like this.