### PR TITLE
Preserve side bar state (opened/closed) on reload.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -60,13 +60,19 @@
     })
     window.addEventListener('message', function () {
       const { currentPageNumber, currentScaleValue } = PDFViewerApplication.pdfViewer
+      const sideBarOpen = PDFViewerApplication.pdfSidebar.isOpen;
       PDFViewerApplication.open(config.path).then(() => {
         const optsOnReload = () => {
           PDFViewerApplication.pdfViewer.currentPageNumber = currentPageNumber
           PDFViewerApplication.pdfViewer.currentScaleValue = currentScaleValue
-          PDFViewerApplication.eventBus.off('documentloaded', optsOnReload)
+          if (!sideBarOpen) {
+            // reload automatically re-opens the sidebar
+            // so close it again if it was closed before reload
+            PDFViewerApplication.pdfSidebar.close()
+          }
+          PDFViewerApplication.eventBus.off('documentinit', optsOnReload)
         }
-        PDFViewerApplication.eventBus.on('documentloaded', optsOnReload)
+        PDFViewerApplication.eventBus.on('documentinit', optsOnReload)
       })
     });
   }, { once: true });


### PR DESCRIPTION
The event trigger had to be changed (from 'documentloaded' to
'documentinit') since the sidebar is re-opened after 'documentloaded'
was fired.

Addresses the secondary discussion in #79, which mentions the sidebar state not being preserved on reload. 