### PR TITLE
fix: Fix scroll location and flickering during reload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,14 +9,23 @@
   "plugins": [
     "@typescript-eslint"
   ],
-  "env": { "node": true, "es6": true },
+  "env": {
+    "node": true,
+    "es6": true
+  },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
   "rules": {
-    "prettier/prettier": ["error", { "singleQuote": true }],
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "endOfLine": "auto"
+      }
+    ],
     "no-empty-function": "off",
     "@typescript-eslint/no-empty-function": "off"
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,8 +60,8 @@
 
     // load() cannot be called before pdf.js is initialized
     // open() makes sure pdf.js is initialized before load()
-    PDFViewerApplication.open(config.path).then(function () {
-      const doc = PDFViewerApplication.pdfDocument
+    PDFViewerApplication.open(config.path).then(async function () {
+      const doc = await pdfjsLib.getDocument(config.path).promise
       doc._pdfInfo.fingerprints = [config.path]
       PDFViewerApplication.load(doc)
     })

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,24 +38,6 @@
         return -1
     }
   }
-  async function reload() {
-      // Prevents flickering of page when PDF is reloaded
-      const oldResetView = PDFViewerApplication.pdfViewer._resetView
-      PDFViewerApplication.pdfViewer._resetView = function () {
-        this._firstPageCapability = (0, pdfjsLib.createPromiseCapability)()
-        this._onePageRenderedCapability = (0, pdfjsLib.createPromiseCapability)()
-        this._pagesCapability = (0, pdfjsLib.createPromiseCapability)()
-
-        this.viewer.textContent = ""
-      }
-
-      // Changing the fingerprint fools pdf.js into keeping scroll position
-      const doc = await pdfjsLib.getDocument(config.path).promise
-      doc._pdfInfo.fingerprints = [config.path]
-      PDFViewerApplication.load(doc)
-
-      PDFViewerApplication.pdfViewer._resetView = oldResetView
-  }
   window.addEventListener('load', async function () {
     const config = loadConfig()
     PDFViewerApplicationOptions.set('cMapUrl', config.cMapUrl)
@@ -84,7 +66,24 @@
       PDFViewerApplication.load(doc)
     })
 
-    window.addEventListener('message', reload());
+    window.addEventListener('message', async function () {
+      // Prevents flickering of page when PDF is reloaded
+      const oldResetView = PDFViewerApplication.pdfViewer._resetView
+      PDFViewerApplication.pdfViewer._resetView = function () {
+        this._firstPageCapability = (0, pdfjsLib.createPromiseCapability)()
+        this._onePageRenderedCapability = (0, pdfjsLib.createPromiseCapability)()
+        this._pagesCapability = (0, pdfjsLib.createPromiseCapability)()
+
+        this.viewer.textContent = ""
+      }
+
+      // Changing the fingerprint fools pdf.js into keeping scroll position
+      const doc = await pdfjsLib.getDocument(config.path).promise
+      doc._pdfInfo.fingerprints = [config.path]
+      PDFViewerApplication.load(doc)
+
+      PDFViewerApplication.pdfViewer._resetView = oldResetView
+    });
   }, { once: true });
 
   window.onerror = function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,10 +38,27 @@
         return -1
     }
   }
-  window.addEventListener('load', function () {
+  async function reload() {
+      // Prevents flickering of page when PDF is reloaded
+      const oldResetView = PDFViewerApplication.pdfViewer._resetView
+      PDFViewerApplication.pdfViewer._resetView = function () {
+        this._firstPageCapability = (0, pdfjsLib.createPromiseCapability)()
+        this._onePageRenderedCapability = (0, pdfjsLib.createPromiseCapability)()
+        this._pagesCapability = (0, pdfjsLib.createPromiseCapability)()
+
+        this.viewer.textContent = ""
+      }
+
+      // Changing the fingerprint fools pdf.js into keeping scroll position
+      const doc = await pdfjsLib.getDocument(config.path).promise
+      doc._pdfInfo.fingerprints = [config.path]
+      PDFViewerApplication.load(doc)
+
+      PDFViewerApplication.pdfViewer._resetView = oldResetView
+  }
+  window.addEventListener('load', async function () {
     const config = loadConfig()
     PDFViewerApplicationOptions.set('cMapUrl', config.cMapUrl)
-    PDFViewerApplication.open(config.path)
     PDFViewerApplication.initializedPromise.then(() => {
       const defaults = config.defaults
       const optsOnLoad = () => {
@@ -58,17 +75,16 @@
       }
       PDFViewerApplication.eventBus.on('documentloaded', optsOnLoad)
     })
-    window.addEventListener('message', function () {
-      const { currentPageNumber, currentScaleValue } = PDFViewerApplication.pdfViewer
-      PDFViewerApplication.open(config.path).then(() => {
-        const optsOnReload = () => {
-          PDFViewerApplication.pdfViewer.currentPageNumber = currentPageNumber
-          PDFViewerApplication.pdfViewer.currentScaleValue = currentScaleValue
-          PDFViewerApplication.eventBus.off('documentloaded', optsOnReload)
-        }
-        PDFViewerApplication.eventBus.on('documentloaded', optsOnReload)
-      })
-    });
+
+    // load() cannot be called before pdf.js is initialized
+    // open() makes sure pdf.js is initialized before load()
+    PDFViewerApplication.open(config.path).then(function () {
+      const doc = PDFViewerApplication.pdfDocument
+      doc._pdfInfo.fingerprints = [config.path]
+      PDFViewerApplication.load(doc)
+    })
+
+    window.addEventListener('message', reload());
   }, { once: true });
 
   window.onerror = function () {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "pdf",
   "displayName": "vscode-pdf",
   "description": "Display pdf file in VSCode.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "tomoki1207",
   "engines": {
-    "vscode": "^1.47.0"
+    "vscode": "^1.46.0"
   },
   "categories": [
     "Programming Languages"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.0",
   "publisher": "tomoki1207",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.47.0"
   },
   "categories": [
     "Programming Languages"

--- a/src/pdfProvider.ts
+++ b/src/pdfProvider.ts
@@ -26,6 +26,7 @@ export class PdfCustomProvider implements vscode.CustomReadonlyEditorProvider {
     this.setActivePreview(preview);
 
     webviewEditor.onDidDispose(() => {
+      preview.dispose();
       this._previews.delete(preview);
     });
 


### PR DESCRIPTION
Makes sure pdf.js restores exact scroll position during reload by overriding the fingerprint
Removes flickering when a document is reloaded
