### PR TITLE
Expose API for registering callbacks when the PDF is clicked

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,15 @@
 "use strict";
 
 (function () {
+  const vscode = acquireVsCodeApi();
+
+  function handleclick(event) {
+    debugger;
+    vscode.postMessage({
+      type: 'clicked',
+      text: event.target.innerText
+    })
+  }
   function loadConfig() {
     const elem = document.getElementById('pdf-preview-config')
     if (elem) {
@@ -73,6 +82,7 @@
         PDFViewerApplication.load(doc)
       })
     })
+    document.getElementById('viewer').addEventListener('click', handleclick)
 
     window.addEventListener('message', async function () {
       // Prevents flickering of page when PDF is reloaded

--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
     "vscode-test": "^1.3.0"
   },
   "extensionKind": [
-    "ui"
+    "ui", "workspace"
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 import { PdfCustomProvider } from './pdfProvider';
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext) {
   const extensionRoot = vscode.Uri.file(context.extensionPath);
+  let callbacks = []
   // Register our custom editor provider
-  const provider = new PdfCustomProvider(extensionRoot);
+  const provider = new PdfCustomProvider(extensionRoot, callbacks);
   context.subscriptions.push(
     vscode.window.registerCustomEditorProvider(
       PdfCustomProvider.viewType,
@@ -17,6 +18,12 @@ export function activate(context: vscode.ExtensionContext): void {
       }
     )
   );
+
+  return {
+      registerOnClickCallback(callback: (contents: string) => any) {
+        callbacks.push(callback)
+      }
+  }
 }
 
 export function deactivate(): void {}

--- a/src/pdfPreview.ts
+++ b/src/pdfPreview.ts
@@ -1,5 +1,7 @@
+import { HookCallbacks } from 'async_hooks';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { MessageChannel } from 'worker_threads';
 import { Disposable } from './disposable';
 
 function escapeAttribute(value: string | vscode.Uri): string {
@@ -14,7 +16,8 @@ export class PdfPreview extends Disposable {
   constructor(
     private readonly extensionRoot: vscode.Uri,
     private readonly resource: vscode.Uri,
-    private readonly webviewEditor: vscode.WebviewPanel
+    private readonly webviewEditor: vscode.WebviewPanel,
+    private callbacks: {(content:string)}[]
   ) {
     super();
     const resourceRoot = resource.with({
@@ -36,6 +39,12 @@ export class PdfPreview extends Disposable {
               'default',
               webviewEditor.viewColumn
             );
+            break;
+          }
+          case 'clicked': {
+            for (const callback of this.callbacks) {
+              callback(message.text)
+            }
             break;
           }
         }

--- a/src/pdfProvider.ts
+++ b/src/pdfProvider.ts
@@ -7,7 +7,10 @@ export class PdfCustomProvider implements vscode.CustomReadonlyEditorProvider {
   private readonly _previews = new Set<PdfPreview>();
   private _activePreview: PdfPreview | undefined;
 
-  constructor(private readonly extensionRoot: vscode.Uri) {}
+  constructor(
+    private readonly extensionRoot: vscode.Uri, 
+    private callbacks: {(content:string)}[]
+  ) {}
 
   public openCustomDocument(uri: vscode.Uri): vscode.CustomDocument {
     return { uri, dispose: (): void => {} };
@@ -20,7 +23,8 @@ export class PdfCustomProvider implements vscode.CustomReadonlyEditorProvider {
     const preview = new PdfPreview(
       this.extensionRoot,
       document.uri,
-      webviewEditor
+      webviewEditor,
+      this.callbacks
     );
     this._previews.add(preview);
     this.setActivePreview(preview);


### PR DESCRIPTION
Possibility for registering a callback for receiving the piece of text that was clicked.

I'm working on an extension to synchronize this to my source format (similar to synctex).
Such an extension could hook into pdfviewer like this:

```
	var pdfviewer = vscode.extensions.getExtension('tomoki1207.pdf');
	if (pdfviewer) {
		pdfviewer.activate().then((api) => {
			api.registerOnClickCallback((content: string) => {
				channel.appendLine(content)
			})
		})
	}
```