### PR TITLE
Removing print event avoiding clash with VScode command palette + open file. #80 #85 #132

### DIFF
--- a/lib/web/viewer.js
+++ b/lib/web/viewer.js
@@ -14635,22 +14635,6 @@ function renderProgress(index, total, l10n) {
     progressPerc.textContent = msg;
   });
 }
-window.addEventListener("keydown", function (event) {
-  if (event.keyCode === 80 && (event.ctrlKey || event.metaKey) && !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
-    window.print();
-    event.preventDefault();
-    event.stopImmediatePropagation();
-  }
-}, true);
-if ("onbeforeprint" in window) {
-  const stopPropagationIfNeeded = function (event) {
-    if (event.detail !== "custom") {
-      event.stopImmediatePropagation();
-    }
-  };
-  window.addEventListener("beforeprint", stopPropagationIfNeeded);
-  window.addEventListener("afterprint", stopPropagationIfNeeded);
-}
 let overlayPromise;
 function ensureOverlay() {
   if (!overlayPromise) {


### PR DESCRIPTION
While this may not be the optimal fix (adding keybind options to the keyboard shortcuts VS code window). This fixes the highly requested issue #80 #85 #132. 

I think most people are using this extension as the name suggests, for pdf**viewing**. Printing can easily be done via a browser or adobe acrobat as an alternative. PDFs alongside code are used for reference.