### PR TITLE
Set font color of popup annotations to black

### DIFF
--- a/lib/web/viewer.css
+++ b/lib/web/viewer.css
@@ -348,7 +348,9 @@
   pointer-events: auto;
 }
 
+/* Modify annotation font color to black :) */
 .annotationLayer .popup > * {
+  color: rgba(0, 0, 0, 1);
   font-size: calc(9px * var(--scale-factor));
 }
 


### PR DESCRIPTION
Set font color of popup annotations to black. Otherwise, font color might appear with default color, which was light grey for me. As a result, yellow popup annotations were not readable. 