### PR TITLE
Respect default sidebar setting on load

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,10 +38,15 @@
         return -1
     }
   }
+  function sidebarView(showSidebar) {
+    return showSidebar ? 1 : 0
+  }
   window.addEventListener('load', async function () {
     const config = loadConfig()
+    const defaults = config.defaults
     PDFViewerApplicationOptions.set('cMapUrl', config.cMapUrl)
     PDFViewerApplicationOptions.set('standardFontDataUrl', config.standardFontDataUrl)
+    PDFViewerApplicationOptions.set('sidebarViewOnLoad', sidebarView(defaults.sidebar))
     const loadOpts = {
       url:config.path,
       useWorkerFetch: false,
@@ -50,7 +55,6 @@
       standardFontDataUrl: config.standardFontDataUrl
     }
     PDFViewerApplication.initializedPromise.then(() => {
-      const defaults = config.defaults
       const optsOnLoad = () => {
         PDFViewerApplication.pdfCursorTools.switchTool(cursorTools(defaults.cursor))
         PDFViewerApplication.pdfViewer.currentScaleValue = defaults.scale


### PR DESCRIPTION
Fixes #187.

## Summary
- map `pdf-preview.default.sidebar` to PDF.js `sidebarViewOnLoad` before opening the document
- keep the existing post-load open/close behavior for the current viewer instance

## Why
`pdf-preview.default.sidebar` was applied after the first `documentloaded` event, but PDF.js can restore `stored.sidebarView` during document initialization. Setting `sidebarViewOnLoad` makes the configured default win over persisted PDF.js sidebar history.

## Test
- `npm run compile`
- `npm run lint`
- packaged and installed the VSIX locally with `code --install-extension pdf-1.2.2.vsix --force`
- opened a PDF with prior sidebar history and confirmed PDF.js persisted `sidebarView: 0` when `pdf-preview.default.sidebar` is false
